### PR TITLE
chore: 🐝 Update SDK - Generate PETSTORE 0.2.0

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,17 +3,17 @@ id: a42e6bcf-a188-4465-a802-4f16cf538a71
 management:
   docChecksum: 857ef722c7de932be28b466fa0fdaabc
   docVersion: 4.0.0
-  speakeasyVersion: 1.476.1
-  generationVersion: 2.495.1
-  releaseVersion: 0.1.5
-  configChecksum: 94d55899443b4feb8677b59b75f2e01b
+  speakeasyVersion: 1.487.0
+  generationVersion: 2.506.0
+  releaseVersion: 0.2.0
+  configChecksum: 9477f6f1938a58e764d1abcfb95589c7
   repoURL: https://github.com/ryan-timothy-albert/simple-go-sdk.git
   installationURL: https://github.com/ryan-timothy-albert/simple-go-sdk
 features:
   go:
     additionalDependencies: 0.1.0
-    constsAndDefaults: 0.1.6
-    core: 3.6.9
+    constsAndDefaults: 0.1.7
+    core: 3.7.0
     defaultEnabledRetries: 0.2.0
     envVarSecurityUsage: 0.3.2
     flattening: 2.81.1
@@ -26,7 +26,7 @@ features:
     responseFormat: 0.1.2
     retries: 2.83.2
     sdkHooks: 0.1.0
-    tests: 0.10.5
+    tests: 0.11.0
     uploadStreams: 0.1.0
 generatedFiles:
   - .gitattributes

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -15,7 +15,7 @@ generation:
   tests:
     generateNewTests: true
 go:
-  version: 0.1.5
+  version: 0.2.0
   additionalDependencies: {}
   allowUnknownFieldsInWeakUnions: false
   clientServerStatusCodesAsErrors: true

--- a/.speakeasy/tests.arazzo.yaml
+++ b/.speakeasy/tests.arazzo.yaml
@@ -1,6 +1,6 @@
 arazzo: 1.0.0
 info:
-  title: Test Suites
+  title: Test Suite
   summary: Created from openapi.json
   version: 0.0.1
 sourceDescriptions:

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,19 +1,21 @@
-speakeasyVersion: 1.476.2
+speakeasyVersion: 1.487.0
 sources:
     petstore-oas:
         sourceNamespace: petstore-oas
-        sourceRevisionDigest: sha256:b1d41d3de9eb1f6122560c06689425c693eba247541142d4ee69c28efd6ad3bf
-        sourceBlobDigest: sha256:77c1a8df1c9555fc226f5752722e51a65c55d424b60f49b7dbdf78e43cc41276
+        sourceRevisionDigest: sha256:e9fe6dc43ec7f6ea3b5ede9170230f824498a3ee83425dc14b3c6bc31d889214
+        sourceBlobDigest: sha256:349d8998fca4ef442f5f315156f349c8f816bc247f93337a06b3cef23fdaca5f
         tags:
             - latest
-            - speakeasy-sdk-regen-1734727867
+            - speakeasy-sdk-regen-1738960490
             - 4.0.0
 targets:
     petstore:
         source: petstore-oas
         sourceNamespace: petstore-oas
-        sourceRevisionDigest: sha256:b1d41d3de9eb1f6122560c06689425c693eba247541142d4ee69c28efd6ad3bf
-        sourceBlobDigest: sha256:77c1a8df1c9555fc226f5752722e51a65c55d424b60f49b7dbdf78e43cc41276
+        sourceRevisionDigest: sha256:e9fe6dc43ec7f6ea3b5ede9170230f824498a3ee83425dc14b3c6bc31d889214
+        sourceBlobDigest: sha256:349d8998fca4ef442f5f315156f349c8f816bc247f93337a06b3cef23fdaca5f
+        codeSamplesNamespace: petstore-oas-go-code-samples
+        codeSamplesRevisionDigest: sha256:8bd5a76d46a2158d91dd0beaac8dfabc1b6b43e102dd24298c4482d400d08765
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -10,8 +10,6 @@ targets:
     petstore:
         target: go
         source: petstore-oas
-        # testing:
-        #     enabled: true
         output: .
         codeSamples:
             registry:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,3 +9,13 @@ Based on:
 - [go v0.0.2] .
 ### Releases
 - [Go v0.0.2] https://github.com/ryan-timothy-albert/simple-go-sdk/releases/tag/v0.0.2 - .
+
+## 2025-02-07 20:34:36
+### Changes
+Based on:
+- OpenAPI Doc  
+- Speakeasy CLI 1.487.0 (2.506.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [go v0.2.0] .
+### Releases
+- [Go v0.2.0] https://github.com/ryan-timothy-albert/simple-go-sdk/releases/tag/v0.2.0 - .

--- a/docs/sdks/pet/README.md
+++ b/docs/sdks/pet/README.md
@@ -287,7 +287,6 @@ package main
 import(
 	"context"
 	"openapi"
-	"openapi/models/operations"
 	"log"
 )
 
@@ -298,7 +297,7 @@ func main() {
         openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
     )
 
-    res, err := s.Pet.FindPetsByStatusTypes(ctx, operations.StatusAvailable.ToPointer())
+    res, err := s.Pet.FindPetsByStatusTypes(ctx, nil)
     if err != nil {
         log.Fatal(err)
     }

--- a/internal/utils/queryparams.go
+++ b/internal/utils/queryparams.go
@@ -65,6 +65,12 @@ func populateQueryParams(queryParams interface{}, globals interface{}, values ur
 			continue
 		}
 
+		constValue := parseConstTag(fieldType)
+		if constValue != nil {
+			values.Add(qpTag.ParamName, *constValue)
+			continue
+		}
+
 		if globals != nil {
 			var globalFound bool
 			fieldType, valType, globalFound = populateFromGlobals(fieldType, valType, queryParamTagKey, globals)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -96,6 +96,16 @@ func AsSecuritySource(security interface{}) func(context.Context) (interface{}, 
 	}
 }
 
+func parseConstTag(field reflect.StructField) *string {
+	value := field.Tag.Get("const")
+
+	if value == "" {
+		return nil
+	}
+
+	return &value
+}
+
 func parseStructTag(tagKey string, field reflect.StructField) map[string]string {
 	tag := field.Tag.Get(tagKey)
 	if tag == "" {

--- a/sdk.go
+++ b/sdk.go
@@ -210,9 +210,9 @@ func New(opts ...SDKOption) *SDK {
 		sdkConfiguration: sdkConfiguration{
 			Language:          "go",
 			OpenAPIDocVersion: "4.0.0",
-			SDKVersion:        "0.1.5",
-			GenVersion:        "2.495.1",
-			UserAgent:         "speakeasy-sdk/go 0.1.5 2.495.1 4.0.0 openapi",
+			SDKVersion:        "0.2.0",
+			GenVersion:        "2.506.0",
+			UserAgent:         "speakeasy-sdk/go 0.2.0 2.506.0 4.0.0 openapi",
 			ServerDefaults: []map[string]string{
 				{
 					"environment": "prod",

--- a/tests/pet_test.go
+++ b/tests/pet_test.go
@@ -9,7 +9,6 @@ import (
 	"openapi"
 	"openapi/internal/utils"
 	"openapi/models/components"
-	"openapi/models/operations"
 	"testing"
 )
 
@@ -99,7 +98,7 @@ func TestPet_FindPetsByStatusTypes(t *testing.T) {
 		openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
 	)
 
-	res, err := s.Pet.FindPetsByStatusTypes(ctx, operations.StatusAvailable.ToPointer())
+	res, err := s.Pet.FindPetsByStatusTypes(ctx, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 200, res.HTTPMeta.Response.StatusCode)
 	assert.NotNil(t, res.Pets)


### PR DESCRIPTION
> [!IMPORTANT]
> Linting report available at: <https://app.speakeasy.com/org/ryan-local/ryan-docs-demo/linting-report/90a913b869191af04dd8a9e3c7efffda>
> OpenAPI Change report available at: <https://app.speakeasy.com/org/ryan-local/ryan-docs-demo/changes-report/fc64c3f4ae82820e995e280274f1c8c7>
# SDK update
Based on:
- OpenAPI Doc  
- Speakeasy CLI 1.487.0 (2.506.0) https://github.com/speakeasy-api/speakeasy
## Versioning

Version Bump Type: [minor] - 🤖 (automated)
## OpenAPI Change Summary


```
└─┬Paths
  └──[➕] path (141:9)
```

| Document Element | Total Changes | Breaking Changes |
|------------------|---------------|------------------|
| paths            | 1             | 0                |



## GO CHANGELOG
## constsAndDefaults: 0.1.7 - 2025-02-04
### :bug: Bug Fixes
- Prevent compilation errors and panics with const query parameters *(commit by [@bflad](https://github.com/bflad))*



## core: 3.7.0 - 2025-02-04
### :bee: New Features
- make testing security example matching more forgiving *(commit by [@ryan-timothy-albert](https://github.com/ryan-timothy-albert))*



## core: 3.6.12 - 2025-01-31
### :bug: Bug Fixes
- fixed handling of default fields in usage snippets and tests, fixed validation of required schema property *(commit by [@tristanspeakeasy](https://github.com/tristanspeakeasy))*



## core: 3.6.11 - 2025-01-29
### :bug: Bug Fixes
- use separate namespaces per ruleset *(commit by [@vishalg0wda](https://github.com/vishalg0wda))*



## core: 3.6.10 - 2025-01-27
### :bug: Bug Fixes
- sort subresponses based on the worst scoring response in the group to ensure that no unreachable code paths are created *(commit by [@idbentley](https://github.com/idbentley))*



## tests: 0.11.0 - 2025-02-06
### :bee: New Features
- support testing for business accounts *(commit by [@ryan-timothy-albert](https://github.com/ryan-timothy-albert))*



