### PR TITLE
chore: 🐝 Update SDK - Generate PETSTORE 0.2.1

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,10 +3,10 @@ id: a42e6bcf-a188-4465-a802-4f16cf538a71
 management:
   docChecksum: 857ef722c7de932be28b466fa0fdaabc
   docVersion: 4.0.0
-  speakeasyVersion: 1.487.0
+  speakeasyVersion: 1.488.0
   generationVersion: 2.506.0
-  releaseVersion: 0.2.0
-  configChecksum: 9477f6f1938a58e764d1abcfb95589c7
+  releaseVersion: 0.2.1
+  configChecksum: cd0dd72e59cd5f848ae8a07ede97e271
   repoURL: https://github.com/ryan-timothy-albert/simple-go-sdk.git
   installationURL: https://github.com/ryan-timothy-albert/simple-go-sdk
 features:

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -15,7 +15,7 @@ generation:
   tests:
     generateNewTests: true
 go:
-  version: 0.2.0
+  version: 0.2.1
   additionalDependencies: {}
   allowUnknownFieldsInWeakUnions: false
   clientServerStatusCodesAsErrors: true

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,21 +1,21 @@
-speakeasyVersion: 1.487.0
+speakeasyVersion: 1.488.0
 sources:
     petstore-oas:
         sourceNamespace: petstore-oas
-        sourceRevisionDigest: sha256:e9fe6dc43ec7f6ea3b5ede9170230f824498a3ee83425dc14b3c6bc31d889214
+        sourceRevisionDigest: sha256:0ec4c28421266c037f90d78e45600be34e1449f0166dbebe9e5a8308bdd55a40
         sourceBlobDigest: sha256:349d8998fca4ef442f5f315156f349c8f816bc247f93337a06b3cef23fdaca5f
         tags:
             - latest
-            - speakeasy-sdk-regen-1738960490
+            - speakeasy-sdk-regen-1739234656
             - 4.0.0
 targets:
     petstore:
         source: petstore-oas
         sourceNamespace: petstore-oas
-        sourceRevisionDigest: sha256:e9fe6dc43ec7f6ea3b5ede9170230f824498a3ee83425dc14b3c6bc31d889214
+        sourceRevisionDigest: sha256:0ec4c28421266c037f90d78e45600be34e1449f0166dbebe9e5a8308bdd55a40
         sourceBlobDigest: sha256:349d8998fca4ef442f5f315156f349c8f816bc247f93337a06b3cef23fdaca5f
         codeSamplesNamespace: petstore-oas-go-code-samples
-        codeSamplesRevisionDigest: sha256:8bd5a76d46a2158d91dd0beaac8dfabc1b6b43e102dd24298c4482d400d08765
+        codeSamplesRevisionDigest: sha256:95f43792d0da4d3dc0ae7ad6cb741ac5a6cc5292063ceeb47e8fdcc6d11cb98c
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -19,3 +19,13 @@ Based on:
 - [go v0.2.0] .
 ### Releases
 - [Go v0.2.0] https://github.com/ryan-timothy-albert/simple-go-sdk/releases/tag/v0.2.0 - .
+
+## 2025-02-11 01:19:32
+### Changes
+Based on:
+- OpenAPI Doc  
+- Speakeasy CLI 1.488.0 (2.506.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [go v0.2.1] .
+### Releases
+- [Go v0.2.1] https://github.com/ryan-timothy-albert/simple-go-sdk/releases/tag/v0.2.1 - .

--- a/sdk.go
+++ b/sdk.go
@@ -210,9 +210,9 @@ func New(opts ...SDKOption) *SDK {
 		sdkConfiguration: sdkConfiguration{
 			Language:          "go",
 			OpenAPIDocVersion: "4.0.0",
-			SDKVersion:        "0.2.0",
+			SDKVersion:        "0.2.1",
 			GenVersion:        "2.506.0",
-			UserAgent:         "speakeasy-sdk/go 0.2.0 2.506.0 4.0.0 openapi",
+			UserAgent:         "speakeasy-sdk/go 0.2.1 2.506.0 4.0.0 openapi",
 			ServerDefaults: []map[string]string{
 				{
 					"environment": "prod",


### PR DESCRIPTION
> [!IMPORTANT]
> Linting report available at: <https://app.speakeasy.com/org/ryan-local/ryan-docs-demo/linting-report/8218bf1d0602e46b212b427bf24d4a2c>
> OpenAPI Change report available at: <https://app.speakeasy.com/org/ryan-local/ryan-docs-demo/changes-report/e45a8957bf516a0e4de64bed9eca45d6>
# SDK update
Based on:
- OpenAPI Doc  
- Speakeasy CLI 1.488.0 (2.506.0) https://github.com/speakeasy-api/speakeasy
## Versioning

Version Bump Type: [patch] - 🤖 (automated)
## OpenAPI Change Summary
No specification changes

## GO CHANGELOG
No relevant generator changes

